### PR TITLE
Rewrite pressure crystal appraisal to use scaling values

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1688,16 +1688,19 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 		. = src.return_text_header()
 
 		. += "<h4>The Pressure Crystal Market</h4> \
-			Pressure crystals! Researchers everywhere love them. But selling a crystal reduces demand. Here you can see what \
-			calibers of crystal are more or less valued than usual.<br><br>\
-			A few well-funded organizations have offered superior rates for crystals within certain measurement ranges. \
-			<br><br>"
-		for (var/i in shippingmarket.pressure_crystal_sales)
-			var/index = text2num(i)
-			var/range_min = (index - 1) * PRESSURE_CRYSTAL_SALES_RANGE_LENGTH
-			var/range_max = index * PRESSURE_CRYSTAL_SALES_RANGE_LENGTH
-			var/mult = shippingmarket.pressure_crystal_sales[i]
-			. += "[range_min] to [range_max] kiloblast: \
+			A few well-funded organizations will pay handsomely for crystals exposed to different pressure values. \
+			The bigger the boom, the higher the payout, although duplicate or similar data will be worth less.\
+			<br><br>\
+			<b>Certain pressure values are of particular interest and will reward bonuses:</b>\
+			<br>"
+		for (var/peak in shippingmarket.pressure_crystal_peaks)
+			var/peak_value = text2num(peak)
+			var/mult = shippingmarket.pressure_crystal_peaks[peak]
+			. += "[peak] kiloblast: \
 				[mult > 1 ? "<B>" : ""]worth [round(mult * 100, 0.01)]% of normal. \
-				[mult > 1 ? "Maximum estimated value: [mult * PRESSURE_CRYSTAL_VALUATION(range_max)]</B> credits." : ""]<br>"
+				[mult > 1 ? "Maximum estimated value: [round(mult * PRESSURE_CRYSTAL_VALUATION(peak_value))]</B> credits." : ""]<br>"
 		. += "<br>"
+		. += "<b>Pressure crystal values already sold:</b>\
+			<br>"
+		for (var/value in shippingmarket.pressure_crystal_sales)
+			. += "[value] kiloblast for [shippingmarket.pressure_crystal_sales[value]] credits.<br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes from using discrete range values to gradual falloff curves, updates the PDA program to handle this and tweaks some balance numbers a bit.
I've provided desmos links if you want to delve into the maths a bit.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hopefully more balanced and dynamic market responses :)